### PR TITLE
Remove license reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@
 ## 개발 정보
 - 개발자: shilberbullet
 - 버전: 1.0
-- 라이선스: MIT License
 
 ## 프로젝트 구조
 


### PR DESCRIPTION
## Summary
- drop MIT License reference in README

## Testing
- `gcc -o poketghost.exe src/*.c -I include -lm` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6845b4a0f7088326b3b1ae90dab7c9c8