### PR TITLE
Refactor stage types

### DIFF
--- a/include/stage.h
+++ b/include/stage.h
@@ -1,32 +1,7 @@
 #ifndef STAGE_H
 #define STAGE_H
 
-#include <stdbool.h>
-#include "yokai.h"
-
-#define REGION_NAME_MAX 32
-#define MAX_ENEMIES 5
-
-typedef enum {
-    TERRAIN_MOUNTAIN,
-    TERRAIN_RIVER,
-    TERRAIN_SEA,
-    TERRAIN_FIELD,
-    TERRAIN_VILLAGE,
-    TERRAIN_COUNT
-} TerrainType;
-
-typedef struct {
-    int stageNumber;
-    bool isBossStage;
-    int minLevel;
-    int maxLevel;
-    int enemyCount;
-    Yokai enemies[MAX_ENEMIES];
-    char region[REGION_NAME_MAX];
-    TerrainType terrain;
-    int hour;
-} StageInfo;
+#include "stage_types.h"
 
 extern StageInfo currentStage;
 

--- a/include/stage_types.h
+++ b/include/stage_types.h
@@ -29,7 +29,6 @@ typedef struct {
     int hour;
 } StageInfo;
 
-extern StageInfo currentStage;
 
 // 지역 이름 배열 선언
 extern const char* regions[REGION_COUNT];

--- a/src/stage.c
+++ b/src/stage.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <string.h>
-#include "stage_types.h"
+#include "stage.h"
 #include "normal_stage.h"
 #include "boss_stage.h"
 #include "text.h"


### PR DESCRIPTION
## Summary
- centralize `StageInfo` and related enums in `stage_types.h`
- include `stage_types.h` from `stage.h`
- adjust `stage.c` to include `stage.h`

## Testing
- `gcc -c src/stage.c -I include -o /tmp/stage.o`

------
https://chatgpt.com/codex/tasks/task_e_6845b4c9c5d083269f455efa8efdf8c5